### PR TITLE
클래스 유틸함수 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/react-dom": "^18",
         "@typescript-eslint/eslint-plugin": "^8.0.1",
         "@typescript-eslint/parser": "^8.0.1",
+        "clsx": "^2.1.1",
         "eslint": "^8",
         "eslint-config-next": "14.2.5",
         "eslint-config-prettier": "^9.1.0",
@@ -28,6 +29,7 @@
         "lint-staged": "^15.2.8",
         "postcss": "^8",
         "prettier": "^3.3.3",
+        "tailwind-merge": "^2.5.2",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
       }
@@ -1263,6 +1265,15 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -5373,6 +5384,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.5.2.tgz",
+      "integrity": "sha512-kjEBm+pvD+6eAwzJL2Bi+02/9LFLal1Gs61+QB7HvTfQQ0aXwC5LGT8PEt1gS0CWKktKe6ysPTAy3cBC5MeiIg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/react-dom": "^18",
     "@typescript-eslint/eslint-plugin": "^8.0.1",
     "@typescript-eslint/parser": "^8.0.1",
+    "clsx": "^2.1.1",
     "eslint": "^8",
     "eslint-config-next": "14.2.5",
     "eslint-config-prettier": "^9.1.0",
@@ -37,6 +38,7 @@
     "lint-staged": "^15.2.8",
     "postcss": "^8",
     "prettier": "^3.3.3",
+    "tailwind-merge": "^2.5.2",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
   }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,15 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+/**
+ * 여러 클래스를 하나로 합칩니다
+ * - clsx를 이용한 조건부 클래스를 쉽게 적용가능
+ * - twMerge로 tailwind 클래스 충돌 해결 및 중복을 제거
+ * @param inputs - 합칠 클래스들 (문자열, 객체, 배열 등)
+ * @returns 클래스 문자열
+ * @see https://github.com/lukeed/clsx
+ * @see https://github.com/dcastil/tailwind-merge
+ */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
`cn` 유틸리티 함수를 추가했어요. `clsx`와 `tailwind-merge` 라이브러리를 함께 사용해서 클래스 관리를 도와주는 유틸이에요.

```ts
import { clsx, type ClassValue } from "clsx";
import { twMerge } from "tailwind-merge";

/**
 * 여러 클래스를 하나로 합칩니다
 * - clsx를 이용한 조건부 클래스를 쉽게 적용가능
 * - twMerge로 tailwind 클래스 충돌 해결 및 중복을 제거
 * @param inputs - 합칠 클래스들 (문자열, 객체, 배열 등)
 * @returns 클래스 문자열
 * @see https://github.com/lukeed/clsx
 * @see https://github.com/dcastil/tailwind-merge
 */
export function cn(...inputs: ClassValue[]) {
  return twMerge(clsx(inputs));
}
```

### 예시
```ts
import { cn } from "@/lib/utils";

function SomeComponent({ isActive, className }) {
  return (
    <div className={cn("px-4 py-2 rounded", isActive && "bg-primary-400", className)}>
      SomeComponent
    </div>
  );
}
```

- 조건에 따라 클래스 적용이 간소화 돼요
- Tailwind 클래스 충돌을 해결해요
- 중복 클래스 제거돼요
- 코드 가독성이 향상돼요