### PR TITLE
feat: Heading, Text 컴포넌트

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -13,7 +13,7 @@ export default function AuthLayout({
         <Button
           variant="text"
           radius="full"
-          className="fixed bottom-0 mx-auto w-40 mb-20 border-[0.2px] shadow-md z-10"
+          className="fixed bottom-0 mx-auto w-40 mb-20 bg-background border-[0.2px] shadow-md z-10"
         >
           미리보기
         </Button>

--- a/src/components/ui/heading.tsx
+++ b/src/components/ui/heading.tsx
@@ -1,0 +1,23 @@
+import { ComponentPropsWithoutRef, ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+const variants = {
+  heading1: "text-3xl md:text-4xl font-bold",
+  heading2: "text-2xl md:text-3xl font-bold",
+  heading3: "text-xl md:text-2xl font-semibold",
+  subtitle1: "text-lg md:text-xl font-medium",
+  subtitle2: "text-base md:text-lg",
+} as const;
+
+export interface HeadingProps extends ComponentPropsWithoutRef<"h1"> {
+  variant?: keyof typeof variants;
+  order?: 1 | 2 | 3 | 4 | 5 | 6;
+  children?: ReactNode;
+  className?: string;
+}
+
+export function Heading({ variant = "heading2", order = 1, children, className }: HeadingProps) {
+  const Component: keyof JSX.IntrinsicElements = `h${order}`;
+  return <Component className={cn(variants[variant], className)}>{children}</Component>;
+}

--- a/src/components/ui/text.tsx
+++ b/src/components/ui/text.tsx
@@ -1,0 +1,25 @@
+import { ComponentPropsWithoutRef, ElementType, ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+const variants = {
+  body1: "text-sm md:text-base",
+  body2: "text-xs md:text-sm",
+} as const;
+
+interface TextProps<T extends ElementType = "span"> {
+  as?: T;
+  variant?: keyof typeof variants;
+  children?: ReactNode;
+  className?: string;
+}
+
+export function Text<T extends ElementType = "span">({
+  as,
+  variant = "body1",
+  children,
+  className,
+}: TextProps & Omit<ComponentPropsWithoutRef<T>, keyof TextProps<T>>) {
+  const Component = as || "span";
+  return <Component className={cn(variants[variant], className)}> {children}</Component>;
+}

--- a/src/components/ui/text.tsx
+++ b/src/components/ui/text.tsx
@@ -7,7 +7,7 @@ const variants = {
   body2: "text-xs md:text-sm",
 } as const;
 
-interface TextProps<T extends ElementType = "span"> {
+export interface TextProps<T extends ElementType = "span"> {
   as?: T;
   variant?: keyof typeof variants;
   children?: ReactNode;


### PR DESCRIPTION
제목, 본문을 나타내주는 Heading, Text 컴포넌트를 추가했어요.

```ts
<Heading>제목1</Heading>
<Heading variant="heading2">제목2</Heading>
<Heading variant="subtitle2">제목3</Heading>
<Heading order={3} variant="subtitle2">제목4</Heading>
```

```ts
<Text>본문</Text>
<Text as="p">본문</Text>
```