### PR TITLE
tab active 상태에서 스타일 효과 추가

### DIFF
--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -91,7 +91,7 @@ export const Tab = forwardRef<HTMLButtonElement, TabProps>(
         aria-controls={`tabpanel-${value}`}
         tabIndex={isSelected ? 0 : -1}
         className={cn(
-          "text-sm font-medium py-2 px-4 rounded-[10px]",
+          "text-sm font-medium py-2 px-4 rounded-[10px] active:scale-[0.96] duration-100 transition-transform",
           currentValue === value ? "bg-foreground border border-foreground text-white" : "border",
           className,
         )}


### PR DESCRIPTION
## 🚀 tab active 상태에서 스타일 효과 추가
### 📝 요약
Thread 바뀐 UI에 맞춰 Tab 누를때 스타일 효과가 추가되었어요
### 🔗 이슈
#22 
### 🖼️ 스크린샷 (선택사항)

https://github.com/user-attachments/assets/79e2dc42-a130-4505-b323-6005084a1b89


### ℹ️ 추가 노트
<!-- 리뷰어가 알아야 할 다른 정보가 있다면 여기에 적어주세요. -->
