### PR TITLE
디자인 페이지 퍼블리싱

### DIFF
--- a/src/app/(auth)/design/page.tsx
+++ b/src/app/(auth)/design/page.tsx
@@ -1,3 +1,150 @@
+import { SignOut } from "@phosphor-icons/react/dist/ssr";
+
+import { Heading } from "@/components/ui/heading";
+import { Tab, TabList, TabPanel, Tabs } from "@/components/ui/tabs";
+
 export default function DesignPage() {
-  return <main></main>;
+  return (
+    <>
+      <header className="fixed top-0 bg-background grid grid-cols-[1fr_50vw_1fr] h-16 w-full px-3 max-w-screen-sm">
+        <div></div>
+        <div className="flex justify-center items-center">
+          <span className="w-8 h-8 bg-primary-300 rounded-full"></span>
+        </div>
+        <div className="flex justify-end items-center">
+          <button type="button" className="w-7 h-7 inline-flex items-center justify-center">
+            <SignOut size={20} />
+            <span className="sr-only">로그아웃</span>
+          </button>
+        </div>
+      </header>
+
+      <main className="min-h-dvh pt-16 pb-[68px]">
+        <h1 className="sr-only">디자인</h1>
+        <Tabs defaultValue="스킨">
+          <TabList className="px-4 my-4">
+            <Tab value="스킨" className="w-28">
+              스킨
+            </Tab>
+            <Tab value="버튼" className="w-28">
+              버튼
+            </Tab>
+            <Tab value="폰트" className="w-28">
+              폰트
+            </Tab>
+          </TabList>
+          <TabPanel value="스킨">
+            <section className="px-3 space-y-2 md:space-y-3">
+              <h1 className="sr-only">스킨 편집</h1>
+              <div>
+                <Heading variant="subtitle2" order={2} className="font-medium">
+                  배경 컬러
+                </Heading>
+                <div className="overflow-x-auto">
+                  <div className="flex gap-3 mt-2 min-w-max">
+                    <button
+                      type="button"
+                      className="flex-shrink-0 w-14 h-14 bg-background rounded-full active:scale-[0.96] duration-100 transition-transform border"
+                    >
+                      <span className="sr-only">기본</span>
+                    </button>
+                    <button
+                      type="button"
+                      className="flex-shrink-0 w-14 h-14 bg-background-muted rounded-full active:scale-[0.96] duration-100 transition-transform"
+                    >
+                      <span className="sr-only">약함</span>
+                    </button>
+                    <button
+                      type="button"
+                      className="flex-shrink-0 w-14 h-14 bg-green-100 rounded-full active:scale-[0.96] duration-100 transition-transform"
+                    >
+                      <span className="sr-only">파스텔 그린</span>
+                    </button>
+                    <button
+                      type="button"
+                      className="flex-shrink-0 w-14 h-14 bg-pink-100 rounded-full active:scale-[0.96] duration-100 transition-transform"
+                    >
+                      <span className="sr-only">파스텔 핑크</span>
+                    </button>
+                    <button
+                      type="button"
+                      className="flex-shrink-0 w-14 h-14 bg-blue-100 rounded-full active:scale-[0.96] duration-100 transition-transform"
+                    >
+                      <span className="sr-only">파스텔 블루</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div>
+                <Heading variant="subtitle2" order={2} className="font-medium">
+                  스티커
+                </Heading>
+                <div className="overflow-x-auto">
+                  <div className="flex gap-3 mt-2 min-w-max">
+                    <button
+                      type="button"
+                      className="flex-shrink-0 w-14 h-14 bg-background rounded-full active:scale-[0.96] duration-100 transition-transform border"
+                    >
+                      <span className="sr-only">기본</span>
+                    </button>
+                    <button
+                      type="button"
+                      className="flex-shrink-0 w-14 h-14 bg-background-muted rounded-full active:scale-[0.96] duration-100 transition-transform"
+                    >
+                      <span className="sr-only">약함</span>
+                    </button>
+                    <button
+                      type="button"
+                      className="flex-shrink-0 w-14 h-14 bg-green-100 rounded-full active:scale-[0.96] duration-100 transition-transform"
+                    >
+                      <span className="sr-only">파스텔 그린</span>
+                    </button>
+                    <button
+                      type="button"
+                      className="flex-shrink-0 w-14 h-14 bg-pink-100 rounded-full active:scale-[0.96] duration-100 transition-transform"
+                    >
+                      <span className="sr-only">파스텔 핑크</span>
+                    </button>
+                    <button
+                      type="button"
+                      className="flex-shrink-0 w-14 h-14 bg-blue-100 rounded-full active:scale-[0.96] duration-100 transition-transform"
+                    >
+                      <span className="sr-only">파스텔 블루</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </section>
+          </TabPanel>
+          <TabPanel value="버튼">
+            <section className="px-3 space-y-2 md:space-y-3">
+              <h1 className="sr-only">버튼 편집</h1>
+              <div>
+                <Heading variant="subtitle2" order={2} className="font-medium">
+                  레이아웃
+                </Heading>
+
+                <div className="space-y-3 mt-2">
+                  <button
+                    type="button"
+                    className="block h-32 md:h-36 w-full bg-background-muted rounded-xl"
+                  >
+                    <span className="sr-only">기본</span>
+                  </button>
+                </div>
+              </div>
+            </section>
+          </TabPanel>
+          <TabPanel value="폰트">
+            <section className="px-3">
+              <h1 className="sr-only">폰트 편집</h1>
+              <Heading variant="subtitle2" order={2} className="font-medium">
+                TODO
+              </Heading>
+            </section>
+          </TabPanel>
+        </Tabs>
+      </main>
+    </>
+  );
 }

--- a/src/app/(auth)/design/page.tsx
+++ b/src/app/(auth)/design/page.tsx
@@ -1,5 +1,7 @@
 import { SignOut } from "@phosphor-icons/react/dist/ssr";
 
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import { Heading } from "@/components/ui/heading";
 import { Tab, TabList, TabPanel, Tabs } from "@/components/ui/tabs";
 
@@ -136,11 +138,46 @@ export default function DesignPage() {
             </section>
           </TabPanel>
           <TabPanel value="폰트">
-            <section className="px-3">
+            <section className="px-3 space-y-2 md:space-y-3">
               <h1 className="sr-only">폰트 편집</h1>
-              <Heading variant="subtitle2" order={2} className="font-medium">
-                TODO
-              </Heading>
+              <div>
+                <Heading variant="subtitle2" order={2} className="font-medium">
+                  종류
+                </Heading>
+                <div className="flex gap-2 mt-2">
+                  <Button type="button" variant="primary">
+                    폰트 A
+                  </Button>
+                  <Button type="button" variant="secondary">
+                    폰트 B
+                  </Button>
+                  <Button type="button" variant="secondary">
+                    폰트 C
+                  </Button>
+                </div>
+              </div>
+              <div>
+                <Heading variant="subtitle2" order={2} className="font-medium">
+                  사이즈
+                </Heading>
+                <div className="flex gap-2 mt-2">
+                  <Button type="button" variant="primary" className="text-xs">
+                    작게
+                  </Button>
+                  <Button type="button" variant="secondary" className="text-sm">
+                    보통
+                  </Button>
+                  <Button type="button" variant="secondary" className="text-base">
+                    크게
+                  </Button>
+                </div>
+              </div>
+              <div>
+                <h1 className="sr-only">폰트 미리보기</h1>
+                <Card className="flex items-center justify-center w-full h-32 mt-10 rounded-2xl">
+                  가나다 ABC
+                </Card>
+              </div>
             </section>
           </TabPanel>
         </Tabs>

--- a/src/components/mobile-navigation.tsx
+++ b/src/components/mobile-navigation.tsx
@@ -17,7 +17,7 @@ const links = [
   {
     id: "링크",
     href: "/links",
-    title: "디자인",
+    title: "링크",
     icon: StackSimple,
   },
   {

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -64,7 +64,7 @@ export function TabList({ children, className }: TabListProps) {
     <div
       role="tablist"
       aria-label={label ?? "tab-list"}
-      className={cn("flex items-center gap-2.5", className)}
+      className={cn("flex items-center gap-2.5 overflow-x-auto", className)}
     >
       {children}
     </div>
@@ -91,7 +91,7 @@ export const Tab = forwardRef<HTMLButtonElement, TabProps>(
         aria-controls={`tabpanel-${value}`}
         tabIndex={isSelected ? 0 : -1}
         className={cn(
-          "text-sm font-medium py-2 px-4 rounded-[10px] active:scale-[0.96] duration-100 transition-transform",
+          "text-sm font-medium py-2 px-4 rounded-[10px] flex-shrink-0 active:scale-[0.96] duration-100 transition-transform",
           currentValue === value ? "bg-foreground border border-foreground text-white" : "border",
           className,
         )}


### PR DESCRIPTION
## 🚀 디자인 페이지 퍼블리싱
### 📝 요약
- 디자인 페이지 퍼블리싱
### 🔗 이슈
#19 
### 🖼️ 스크린샷 (선택사항)

https://github.com/user-attachments/assets/c4bea533-8973-45d6-a12e-549988ddf199


### ℹ️ 추가 노트
- 폰트: 구체적으로 어떤 디자인 바꿀지 정하면 퍼블리싱 하겠습니답
- 레이아웃: 피그마에 먼저 이미지를 그려야할 것 같아요
