### PR TITLE
foreground-inverted 추가

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,6 +10,7 @@
     --foreground: 24 24 27; /* zinc-900 */
     --foreground-muted: 24 24 27; /* zinc-900 */
     --foreground-disabled: 24 24 27; /* zinc-900 */
+    --foreground-inverted: 255 255 255; /* white */
     --border: 212 212 216; /* zinc-300 */
     --accent: 141 165 233; /* sky-500 */
     --danger: 239 68 68; /* red-500 */
@@ -23,6 +24,7 @@
     --foreground: 244 244 255; /* zinc-100 */
     --foreground-muted: 244 244 255 / 0.55; /* zinc-100 */
     --foreground-disabled: 244 244 255 / 0.4; /* zinc-100 */
+    --foreground-inverted: 244 244 255; /* zinc-100 */
     --border: 113 113 122; /* zinc-500 */
     --accent: 2 132 199; /* sky-600 */
     --danger: 239 68 68; /* red-500 */

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,6 +21,7 @@ const config: Config = {
           DEFAULT: "rgb(var(--foreground) / <alpha-value>)",
           muted: "rgb(var(--foreground-muted) / 0.55)",
           disabled: "rgb(var(--foreground-disabled) / 0.4)",
+          inverted: "rgb(var(--foreground-inverted) / <alpha-value>)",
         },
         border: "rgb(var(--border) / <alpha-value>)",
         accent: "rgb(var(--accent) / <alpha-value>)",


### PR DESCRIPTION
## 🚀 foreground-inverted 추가
### 📝 요약
배경과 반전된 폰트 색을 나타내는 `foreground-inverted` 추가

```css
@layer base {
  :root {
    --background: 255 255 255; /* white */
    --background-muted: 244 244 245; /* zinc-100 */
    --background-disabled: 228 228 231; /* zinc-200 */
    --foreground: 24 24 27; /* zinc-900 */
    --foreground-muted: 24 24 27; /* zinc-900 */
    --foreground-disabled: 24 24 27; /* zinc-900 */
    --foreground-inverted: 255 255 255; /* white */ ✅
    --border: 212 212 216; /* zinc-300 */
    --accent: 141 165 233; /* sky-500 */
    --danger: 239 68 68; /* red-500 */
    --dimmed: 0 0 0;
  }

  .dark {
    --background: 24 24 27; /* zinc-900 */
    --background-muted: 63 63 70; /* zinc-700 */
    --background-disabled: 113 113 122; /* zinc-500 */
    --foreground: 244 244 255; /* zinc-100 */
    --foreground-muted: 244 244 255 / 0.55; /* zinc-100 */
    --foreground-disabled: 244 244 255 / 0.4; /* zinc-100 */
    --foreground-inverted: 244 244 255; /* zinc-100 */ ✅
    --border: 113 113 122; /* zinc-500 */
    --accent: 2 132 199; /* sky-600 */
    --danger: 239 68 68; /* red-500 */
  }
```
### 🔗 이슈
#17 
### 🖼️ 스크린샷 (선택사항)
<!-- 보여줄 내용이 있는 경우 스크린샷을 추가해주세요. -->
### ℹ️ 추가 노트
<!-- 리뷰어가 알아야 할 다른 정보가 있다면 여기에 적어주세요. -->
