### PR TITLE
test: 화면 소개를 위한 ui 수정

### DIFF
--- a/src/app/(public)/signup/link/page.tsx
+++ b/src/app/(public)/signup/link/page.tsx
@@ -1,6 +1,13 @@
 import Link from "next/link";
 
-import { Trash, Link as Chain } from "@phosphor-icons/react/dist/ssr";
+import {
+  Trash,
+  Link as Chain,
+  InstagramLogo,
+  FacebookLogo,
+  XLogo,
+  ThreadsLogo,
+} from "@phosphor-icons/react/dist/ssr";
 
 import {
   AppHeader,
@@ -34,7 +41,9 @@ export default function RegisterLinksPage() {
                     variant="muted"
                     className="rounded-2xl w-16 h-16 flex flex-col items-center"
                   >
-                    <span className="min-w-10 min-h-10 block bg-primary-300 rounded-xl mt-3"></span>
+                    <span className="min-w-10 min-h-10 block bg-primary-300 rounded-xl mt-3">
+                      <Chain size={40} />
+                    </span>
                   </Card>
                   <span>커스텀</span>
                 </button>
@@ -45,9 +54,9 @@ export default function RegisterLinksPage() {
                     variant="muted"
                     className="rounded-2xl w-16 h-16 flex flex-col items-center"
                   >
-                    <span className="min-w-10 min-h-10 block bg-primary-300 rounded-xl mt-3"></span>
+                    <InstagramLogo size={48} className="mt-2" />
                   </Card>
-                  <span>커스텀</span>
+                  <span>인스타그램</span>
                 </button>
               </li>
               <li>
@@ -56,9 +65,9 @@ export default function RegisterLinksPage() {
                     variant="muted"
                     className="rounded-2xl w-16 h-16 flex flex-col items-center"
                   >
-                    <span className="min-w-10 min-h-10 block bg-primary-300 rounded-xl mt-3"></span>
+                    <FacebookLogo size={48} className="mt-2" />
                   </Card>
-                  <span>커스텀</span>
+                  <span>페이스북</span>
                 </button>
               </li>
               <li>
@@ -67,9 +76,9 @@ export default function RegisterLinksPage() {
                     variant="muted"
                     className="rounded-2xl w-16 h-16 flex flex-col items-center"
                   >
-                    <span className="min-w-10 min-h-10 block bg-primary-300 rounded-xl mt-3"></span>
+                    <XLogo size={48} className="mt-2" />
                   </Card>
-                  <span>커스텀</span>
+                  <span>X</span>
                 </button>
               </li>
               <li>
@@ -78,19 +87,17 @@ export default function RegisterLinksPage() {
                     variant="muted"
                     className="rounded-2xl w-16 h-16 flex flex-col items-center"
                   >
-                    <span className="min-w-10 min-h-10 block bg-primary-300 rounded-xl mt-3"></span>
+                    <ThreadsLogo size={48} className="mt-2" />
                   </Card>
-                  <span>커스텀</span>
+                  <span>쓰레드</span>
                 </button>
               </li>
             </ul>
-            <ul className="flex flex-col gap-4 px-2 mt-10">
+            <ul className="flex flex-col gap-4 px-2 mt-20">
               <li>
                 <Card variant="default" className="rounded-2xl flex p-0 items-center">
-                  <span className="flex items-center w-8 h-8 mx-3 justify-center">
-                    <span className="flex items-center min-w-10 min-h-10 bg-primary-300 rounded-xl mt-0.5 p-1.5">
-                      <Chain size={28} />
-                    </span>
+                  <span className="flex items-center h-8 mx-3 justify-center">
+                    <InstagramLogo size={40} />
                   </span>
                   <input
                     type="text"
@@ -104,66 +111,15 @@ export default function RegisterLinksPage() {
               </li>
               <li>
                 <Card variant="default" className="rounded-2xl flex p-0 items-center">
-                  <span className="flex items-center w-8 h-8 mx-3 justify-center">
-                    <span className="flex items-center min-w-10 min-h-10 bg-primary-300 rounded-xl mt-0.5 p-1.5">
+                  <span className="flex items-center w-8 h-8 mx-4 justify-center">
+                    <span className="flex items-center bg-primary-300 rounded-xl mt-0.5 p-1.5">
                       <Chain size={28} />
                     </span>
                   </span>
                   <input
                     type="text"
                     className="flex-auto items-center px-3 py-4 w-full h-7 mt-4 mb-4"
-                    placeholder="https://instagram.com/"
-                  ></input>
-                  <button className="flex-none items-center w-7 h-7 m-2 justify-center">
-                    <Trash size={18} />
-                  </button>
-                </Card>
-              </li>
-              <li>
-                <Card variant="default" className="rounded-2xl flex p-0 items-center">
-                  <span className="flex items-center w-8 h-8 mx-3 justify-center">
-                    <span className="flex items-center min-w-10 min-h-10 bg-primary-300 rounded-xl mt-0.5 p-1.5">
-                      <Chain size={28} />
-                    </span>
-                  </span>
-                  <input
-                    type="text"
-                    className="flex-auto items-center px-3 py-4 w-full h-7 mt-4 mb-4"
-                    placeholder="https://instagram.com/"
-                  ></input>
-                  <button className="flex-none items-center w-7 h-7 m-2 justify-center">
-                    <Trash size={18} />
-                  </button>
-                </Card>
-              </li>
-              <li>
-                <Card variant="default" className="rounded-2xl flex p-0 items-center">
-                  <span className="flex items-center w-8 h-8 mx-3 justify-center">
-                    <span className="flex items-center min-w-10 min-h-10 bg-primary-300 rounded-xl mt-0.5 p-1.5">
-                      <Chain size={28} />
-                    </span>
-                  </span>
-                  <input
-                    type="text"
-                    className="flex-auto items-center px-3 py-4 w-full h-7 mt-4 mb-4"
-                    placeholder="https://instagram.com/"
-                  ></input>
-                  <button className="flex-none items-center w-7 h-7 m-2 justify-center">
-                    <Trash size={18} />
-                  </button>
-                </Card>
-              </li>
-              <li>
-                <Card variant="default" className="rounded-2xl flex p-0 items-center">
-                  <span className="flex items-center w-8 h-8 mx-3 justify-center">
-                    <span className="flex items-center min-w-10 min-h-10 bg-primary-300 rounded-xl mt-0.5 p-1.5">
-                      <Chain size={28} />
-                    </span>
-                  </span>
-                  <input
-                    type="text"
-                    className="flex-auto items-center px-3 py-4 w-full h-7 mt-4 mb-4"
-                    placeholder="https://instagram.com/"
+                    placeholder="URL을 입력해주세요"
                   ></input>
                   <button className="flex-none items-center w-7 h-7 m-2 justify-center">
                     <Trash size={18} />

--- a/src/app/(public)/signup/link/page.tsx
+++ b/src/app/(public)/signup/link/page.tsx
@@ -1,4 +1,6 @@
-import { Trash, Link } from "@phosphor-icons/react/dist/ssr";
+import Link from "next/link";
+
+import { Trash, Link as Chain } from "@phosphor-icons/react/dist/ssr";
 
 import {
   AppHeader,
@@ -87,7 +89,7 @@ export default function RegisterLinksPage() {
                 <Card variant="default" className="rounded-2xl flex p-0 items-center">
                   <span className="flex items-center w-8 h-8 mx-3 justify-center">
                     <span className="flex items-center min-w-10 min-h-10 bg-primary-300 rounded-xl mt-0.5 p-1.5">
-                      <Link size={28} />
+                      <Chain size={28} />
                     </span>
                   </span>
                   <input
@@ -104,7 +106,7 @@ export default function RegisterLinksPage() {
                 <Card variant="default" className="rounded-2xl flex p-0 items-center">
                   <span className="flex items-center w-8 h-8 mx-3 justify-center">
                     <span className="flex items-center min-w-10 min-h-10 bg-primary-300 rounded-xl mt-0.5 p-1.5">
-                      <Link size={28} />
+                      <Chain size={28} />
                     </span>
                   </span>
                   <input
@@ -121,7 +123,7 @@ export default function RegisterLinksPage() {
                 <Card variant="default" className="rounded-2xl flex p-0 items-center">
                   <span className="flex items-center w-8 h-8 mx-3 justify-center">
                     <span className="flex items-center min-w-10 min-h-10 bg-primary-300 rounded-xl mt-0.5 p-1.5">
-                      <Link size={28} />
+                      <Chain size={28} />
                     </span>
                   </span>
                   <input
@@ -138,7 +140,7 @@ export default function RegisterLinksPage() {
                 <Card variant="default" className="rounded-2xl flex p-0 items-center">
                   <span className="flex items-center w-8 h-8 mx-3 justify-center">
                     <span className="flex items-center min-w-10 min-h-10 bg-primary-300 rounded-xl mt-0.5 p-1.5">
-                      <Link size={28} />
+                      <Chain size={28} />
                     </span>
                   </span>
                   <input
@@ -155,7 +157,7 @@ export default function RegisterLinksPage() {
                 <Card variant="default" className="rounded-2xl flex p-0 items-center">
                   <span className="flex items-center w-8 h-8 mx-3 justify-center">
                     <span className="flex items-center min-w-10 min-h-10 bg-primary-300 rounded-xl mt-0.5 p-1.5">
-                      <Link size={28} />
+                      <Chain size={28} />
                     </span>
                   </span>
                   <input
@@ -171,10 +173,10 @@ export default function RegisterLinksPage() {
             </ul>
             <div className="flex flex-col gap-2 px-2 mt-20">
               <Button variant="primary" size="large">
-                다음
+                <Link href="/signup/welcome">다음</Link>
               </Button>
               <Button variant="text" size="large">
-                건너뛰기
+                <Link href="/signup/welcome">건너뛰기</Link>
               </Button>
             </div>
           </section>

--- a/src/app/(public)/signup/welcome/page.tsx
+++ b/src/app/(public)/signup/welcome/page.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import { Button } from "@/components/ui/button";
 import { Heading } from "@/components/ui/heading";
 import { Text } from "@/components/ui/text";
@@ -23,7 +25,7 @@ export default function WelcomePage() {
             </span>
           </div>
           <Button variant="primary" size="large" className="h-14 rounded-lg">
-            시작하기
+            <Link href="/userscreen">시작하기</Link>
           </Button>
         </div>
       </main>

--- a/src/app/(public)/signup/welcome/page.tsx
+++ b/src/app/(public)/signup/welcome/page.tsx
@@ -25,7 +25,7 @@ export default function WelcomePage() {
             </span>
           </div>
           <Button variant="primary" size="large" className="h-14 rounded-lg">
-            <Link href="/userscreen">시작하기</Link>
+            <Link href="/links">시작하기</Link>
           </Button>
         </div>
       </main>


### PR DESCRIPTION
## 🚀 화면 소개용 링크 추가 및 링크연결 아이콘 임시 추가
### 📝 요약
1. /signup/link -> `다음` `건너뛰기` 버튼 클릭 시 /signup/welcome 이동
2.  /signup/welcome  -> `시작하기` 버튼 클릭 시 /userscreen 이동
3. 링크 연결 아이콘 임시 배치
### 🔗 이슈
#36 
### 🖼️ 스크린샷 (선택사항)
![화면 캡처 2024-08-23 134229](https://github.com/user-attachments/assets/84d451ad-832e-4b5c-bfa0-bfd7a2a948a0)

### ℹ️ 추가 노트
화면 설명용 임의 수정입니다. 차후 변경 예정.
