### PR TITLE
db 함수 간소화

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -3,31 +3,13 @@ import mysql, { PoolConnection } from "mysql2/promise";
 /**
  * @see https://sidorares.github.io/node-mysql2/docs#using-connection-pools
  */
-export const pool = mysql.createPool({
+const pool = mysql.createPool({
   host: process.env.DB_HOST,
   user: process.env.DB_USER,
   password: process.env.DB_PASSWORD,
   database: process.env.DB_NAME,
   connectionLimit: 5,
 });
-
-/**
- * SQL 쿼리를 실행하고 결과를 반환합니다
- *
- * @param sql - 실행할 SQL 쿼리 문자열
- * @param values - SQL 쿼리에 바인딩할 값들의 배열 (옵션)
- * @returns 쿼리 실행 결과
- *
- * @example
- * const books = await query<User[]>('SELECT * FROM book WHERE count > ?', [10]);
- *
- * @throws 쿼리 실행 중 오류가 발생하면 예외를 던집니다.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function query<T>(sql: string, values?: any[]) {
-  const [rows] = await pool.query(sql, values);
-  return rows as T;
-}
 
 /**
  * 트랜잭션 내에서 데이터베이스 작업을 실행합니다
@@ -44,7 +26,7 @@ export async function query<T>(sql: string, values?: any[]) {
  *
  * @throws 트랜잭션 실행 중 오류가 발생하면 롤백 후 예외를 던집니다.
  */
-export async function trx<T>(callback: (connection: PoolConnection) => Promise<T>) {
+async function trx<T>(callback: (connection: PoolConnection) => Promise<T>) {
   const connection = await pool.getConnection();
 
   try {
@@ -60,3 +42,5 @@ export async function trx<T>(callback: (connection: PoolConnection) => Promise<T
     connection.release();
   }
 }
+
+export { pool as db, trx };


### PR DESCRIPTION
## 🚀 db 함수 간소화
### 📝 요약
- 조회 / 삽입,수정,삭제 리턴 타입이 복잡해서 간소화 시킴
- ref: https://sidorares.github.io/node-mysql2/docs/documentation/typescript-examples#type-specification
- 각 쿼리별 모든 타입 대응을 작성하기엔 시간이 비효율적인 것 같아서 `pool` 객체 그대로 쓰기로 결정

```ts
import { db } from "@/lib/db";

db.query("SELECT...");
```
### 🔗 이슈
#57 
### 🖼️ 스크린샷 (선택사항)
<!-- 보여줄 내용이 있는 경우 스크린샷을 추가해주세요. -->
### ℹ️ 추가 노트
<!-- 리뷰어가 알아야 할 다른 정보가 있다면 여기에 적어주세요. -->
