### PR TITLE
링크 삭제시 순서 조정

### DIFF
--- a/src/app/api/links/route.ts
+++ b/src/app/api/links/route.ts
@@ -71,7 +71,6 @@ export async function POST(request: Request) {
 }
 
 /**
- *
  * @see https://github.com/2hundred2ne2/in_my_link/issues/62
  */
 export async function GET(request: NextRequest) {

--- a/src/components/links/link-list-editor.tsx
+++ b/src/components/links/link-list-editor.tsx
@@ -139,11 +139,14 @@ export function LinkListEditor({ links: initialLinks = [] }: LinkListEditorProps
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          userId: 1, // FIXME 인증된 사용자 ID
-          type: newLink.type,
-          title: newLink.title,
-          image: newLink.image,
-          url: newLink.url,
+          links: [
+            {
+              type: newLink.type,
+              title: newLink.title,
+              image: newLink.image,
+              url: newLink.url,
+            },
+          ],
         }),
       });
 
@@ -151,7 +154,7 @@ export function LinkListEditor({ links: initialLinks = [] }: LinkListEditorProps
         throw new Error("링크 추가에 실패했습니다");
       }
 
-      const savedLink = await response.json();
+      const [savedLink] = await response.json();
 
       // 서버에서 받은 ID로 업데이트
       setLinks((prevLinks) =>


### PR DESCRIPTION
## 🚀 링크 삭제시 순서 조정
### 📝 요약
- 링크 삭제시 순서 조정
  - 링크 삭제시 링크들의 순서가 조정됩니다. 예를들어 order 1, 2, 3 에서 2를 삭제하면, order 3이 2로 바뀌게 돼요-
- 링크 관리 페이지에서 링크 추가를 API에 맞게 요청 본문을 객체에서 배열로 변환했어요
### 🔗 이슈
#63 
### 🖼️ 스크린샷 (선택사항)
<!-- 보여줄 내용이 있는 경우 스크린샷을 추가해주세요. -->
### ℹ️ 추가 노트
<!-- 리뷰어가 알아야 할 다른 정보가 있다면 여기에 적어주세요. -->
