### PR TITLE
링크 관리 중간 점검 전 수정

### DIFF
--- a/src/app/api/links/route.ts
+++ b/src/app/api/links/route.ts
@@ -35,7 +35,7 @@ export async function POST(request: Request) {
         userId,
         link.type,
         link.title,
-        link.image,
+        `/images/${link.type}-logo.png`,
         link.url,
         order++,
         new Date(),
@@ -93,7 +93,7 @@ export async function GET(request: NextRequest) {
       [users[0].id],
     );
 
-    return NextResponse.json(links, { status: 201 });
+    return NextResponse.json(links, { status: 200 });
   } catch (error) {
     console.error("[GET] /api/links: \n", error);
     return NextResponse.json({ message: " Internal Server Error" }, { status: 500 });

--- a/src/components/links/link-list-editor.tsx
+++ b/src/components/links/link-list-editor.tsx
@@ -144,7 +144,6 @@ export function LinkListEditor({ links: initialLinks = [] }: LinkListEditorProps
             {
               type: newLink.type,
               title: newLink.title,
-              image: newLink.image,
               url: newLink.url,
             },
           ],

--- a/src/components/links/link-list-item.tsx
+++ b/src/components/links/link-list-item.tsx
@@ -227,6 +227,11 @@ export function LinkListItem({
     return username.trim() !== "" ? username : type;
   })();
 
+  // 이미지가 있고 커스텀 로고가 아닌 경우에만 표시
+  const hasImage = Boolean(image);
+  const isCustomLogo = image?.includes("custom-logo");
+  const shouldShowDeleteImageButton = hasImage && !isCustomLogo;
+
   if (!isEdit) {
     return (
       <Card
@@ -295,14 +300,17 @@ export function LinkListItem({
             />
           </button>
           {/* 이미지 삭제 버튼 */}
-          <button
-            type="button"
-            className="absolute -bottom-1 -right-1 inline-flex min-h-[18px] min-w-[18px] items-center justify-center rounded-full bg-danger text-foreground-inverted"
-            onClick={() => onClickDeleteImage(id)}
-          >
-            <span className="sr-only">이미지 삭제</span>
-            <Trash size={14} />
-          </button>
+
+          {shouldShowDeleteImageButton && (
+            <button
+              type="button"
+              className="absolute -bottom-1 -right-1 inline-flex min-h-[18px] min-w-[18px] items-center justify-center rounded-full bg-danger text-foreground-inverted"
+              onClick={() => onClickDeleteImage(id)}
+            >
+              <span className="sr-only">이미지 삭제</span>
+              <Trash size={14} />
+            </button>
+          )}
         </div>
 
         <EditableText

--- a/src/components/links/link-list-item.tsx
+++ b/src/components/links/link-list-item.tsx
@@ -5,7 +5,14 @@ import { useState } from "react";
 
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { CaretDown, CaretUp, DotsSixVertical, PencilSimple, Trash } from "@phosphor-icons/react";
+import {
+  ArrowSquareOut,
+  CaretDown,
+  CaretUp,
+  DotsSixVertical,
+  PencilSimple,
+  Trash,
+} from "@phosphor-icons/react";
 import toast from "react-hot-toast";
 
 import { ENV } from "@/constants/env";
@@ -346,6 +353,12 @@ export function LinkListItem({
 
       {/* footer */}
       <div className="flex justify-end py-3 pr-3">
+        <a target="_blank" rel="noopener noreferrer" href={url}>
+          <Button type="button" variant="text" className="min-h-7 min-w-7 rounded-full p-0">
+            <span className="sr-only">링크 바로가기</span>
+            <ArrowSquareOut size={16} />
+          </Button>
+        </a>
         <Button
           type="button"
           variant="text"

--- a/src/components/links/link-list-item.tsx
+++ b/src/components/links/link-list-item.tsx
@@ -268,8 +268,10 @@ export function LinkListItem({
           </div>
         </div>
 
-        <div className="flex min-h-16 w-full items-center justify-center px-3 py-4">
-          <Text className="w-full text-center font-medium">{displayTitle}</Text>
+        <div className="flex min-h-16 w-full items-center justify-center px-20 py-4">
+          <Text as="p" className="overflow-hidden break-words text-center text-sm font-medium">
+            {displayTitle}
+          </Text>
         </div>
 
         <div className="absolute right-3 top-1/2 flex h-full -translate-y-1/2 items-center">

--- a/src/components/links/link-list-item/custom-link-editor.tsx
+++ b/src/components/links/link-list-item/custom-link-editor.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+
+import { PencilSimple } from "@phosphor-icons/react";
+import toast from "react-hot-toast";
+
+import { EditableText } from "@/components/ui/editable-text";
+import { ENV } from "@/constants/env";
+import { Link } from "@/types/link";
+
+interface CustomLinkEditorProps {
+  id: Link["id"];
+  url: Link["url"];
+  title?: Link["title"];
+  image?: Link["image"];
+  onChangeUrl: (url: string) => void;
+}
+
+export function CustomLinkEditor({ id, url, title, image, onChangeUrl }: CustomLinkEditorProps) {
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const handleChangeUrl = async (value: string) => {
+    const newUrl = value.trim();
+
+    if (newUrl.length === 0) {
+      setErrorMessage("URL을 입력해주세요");
+      onChangeUrl(value);
+      return;
+    }
+
+    if (newUrl.length > 254) {
+      setErrorMessage("입력가능한 길이를 초과했어요");
+      onChangeUrl(value);
+      return;
+    }
+
+    const urlPattern = /^(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})([/\w .-]*)*\/?$/;
+    if (!urlPattern.test(newUrl)) {
+      setErrorMessage("올바른 URL 형식을 입력해주세요");
+      onChangeUrl(value);
+      return;
+    }
+
+    setErrorMessage("");
+    onChangeUrl(newUrl);
+
+    try {
+      const response = await fetch(`${ENV.apiUrl}/api/links/${id}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          id,
+          title,
+          image,
+          userId: 1, //FIXME: 인증된 회원 아이디
+          url: newUrl,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error("URL 수정에 실패했습니다");
+      }
+    } catch (error) {
+      console.error("URL 수정 중 오류 발생:", error);
+      toast("URL 수정에 실패했어요. 잠시후에 다시 시도해주세요");
+    }
+  };
+
+  return (
+    <EditableText
+      label="URL"
+      value={url}
+      rightIcon={<PencilSimple size={16} className="ml-2 flex-shrink-0" />}
+      errorMessage={errorMessage}
+      onChange={handleChangeUrl}
+    />
+  );
+}

--- a/src/components/links/link-list-item/index.ts
+++ b/src/components/links/link-list-item/index.ts
@@ -1,0 +1,1 @@
+export * from "./link-list-item";

--- a/src/components/links/link-list-item/link-image.tsx
+++ b/src/components/links/link-list-item/link-image.tsx
@@ -1,0 +1,43 @@
+import Image from "next/image";
+
+import { Trash } from "@phosphor-icons/react";
+
+interface LinkImageProps {
+  src?: string;
+  alt: string;
+  onDeleteImage: () => void;
+}
+
+export function LinkImage({ src, alt, onDeleteImage }: LinkImageProps) {
+  // 이미지가 있고 커스텀 로고가 아닌 경우에만 표시
+  const hasImage = Boolean(src);
+  const isCustomLogo = src?.includes("custom-logo");
+  const shouldShowDeleteImageButton = hasImage && !isCustomLogo;
+
+  return (
+    <>
+      <div className="relative flex items-center">
+        <button type="button">
+          <Image
+            src={src ?? "/images/custom-logo.png"}
+            alt={alt}
+            width={256}
+            height={256}
+            className="inline-block h-8 min-w-8 max-w-8 rounded-xl"
+          />
+        </button>
+        {/* 이미지 삭제 버튼 */}
+        {shouldShowDeleteImageButton && (
+          <button
+            type="button"
+            className="absolute -bottom-1 -right-1 inline-flex min-h-[18px] min-w-[18px] items-center justify-center rounded-full bg-danger text-foreground-inverted"
+            onClick={onDeleteImage}
+          >
+            <span className="sr-only">이미지 삭제</span>
+            <Trash size={14} />
+          </button>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/components/links/link-list-item/link-list-item.tsx
+++ b/src/components/links/link-list-item/link-list-item.tsx
@@ -15,33 +15,36 @@ import {
 } from "@phosphor-icons/react";
 import toast from "react-hot-toast";
 
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { EditableText } from "@/components/ui/editable-text";
+import { Text } from "@/components/ui/text";
 import { ENV } from "@/constants/env";
 import { getSnsUrl } from "@/lib/utils";
-import { LinkType } from "@/types/link";
+import { Link } from "@/types/link";
 
-import { Button } from "../ui/button";
-import { Card } from "../ui/card";
-import { EditableText } from "../ui/editable-text";
-import { Text } from "../ui/text";
+import { CustomLinkEditor } from "./custom-link-editor";
+import { LinkImage } from "./link-image";
+import { SocialLinkEditor } from "./social-link-editor";
 
 interface LinkListItemProps {
   /** 링크 id */
-  id: number;
+  id: Link["id"];
 
   /** 링크 제목 */
-  title?: string;
+  title?: Link["title"];
 
   /** 링크 URL */
-  url: string;
+  url: Link["url"];
 
   /** 링크 이미지 */
-  image?: string;
+  image?: Link["image"];
+
+  /** 링크 타입 */
+  type: Link["type"];
 
   /** 편집 모드 여부 */
   isEdit: boolean;
-
-  /** 링크 타입 */
-  type: LinkType;
 
   /** 편집 모드로 전환될 때 호출되는 콜백 함수 */
   onEditStart: (id: number) => void;
@@ -112,7 +115,7 @@ export function LinkListItem({
      */
     transition,
   } = useSortable({
-    id: id,
+    id,
   });
 
   const style = {
@@ -162,56 +165,6 @@ export function LinkListItem({
     }
   };
 
-  const handleChnageUrl = async (value: string) => {
-    const newUrl = value.trim();
-
-    if (newUrl.length === 0) {
-      setErrorMessage({ ...errorMessage, url: "URL을 입력해주세요" });
-      onChangeUrl(id, value);
-      return;
-    }
-
-    if (newUrl.length > 254) {
-      setErrorMessage({ ...errorMessage, url: "입력가능한 길이를 초과했어요" });
-      onChangeUrl(id, value);
-      return;
-    }
-
-    const urlPattern = /^(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})([/\w .-]*)*\/?$/;
-
-    if (!urlPattern.test(newUrl)) {
-      setErrorMessage({ ...errorMessage, url: "올바른 URL 형식을 입력해주세요" });
-      onChangeUrl(id, value);
-      return;
-    }
-
-    setErrorMessage({ ...errorMessage, url: "" });
-    onChangeUrl(id, newUrl);
-
-    try {
-      const response = await fetch(`${ENV.apiUrl}/api/links/${id}`, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          id,
-          title,
-          image,
-          userId: 1, //FIXME: 인증된 회원 아이디
-          url: newUrl,
-        }),
-      });
-
-      if (!response.ok) {
-        throw new Error("URL 수정에 실패했습니다");
-      }
-    } catch (error) {
-      console.error("링크 수정 중 오류 발생:", error);
-      toast("URL 수정에 실패했어요. 잠시후에 다시 시도해주세요");
-    }
-  };
-
   /**
    * 1. title이 존재하고 비어있지 않으면 title을 사용
    * 2. title이 없거나 비어있을 때:
@@ -233,11 +186,6 @@ export function LinkListItem({
 
     return username.trim() !== "" ? username : type;
   })();
-
-  // 이미지가 있고 커스텀 로고가 아닌 경우에만 표시
-  const hasImage = Boolean(image);
-  const isCustomLogo = image?.includes("custom-logo");
-  const shouldShowDeleteImageButton = hasImage && !isCustomLogo;
 
   if (!isEdit) {
     return (
@@ -298,29 +246,7 @@ export function LinkListItem({
     >
       {/* header */}
       <div className="flex items-center py-4 pl-6 pr-3">
-        <div className="relative flex items-center">
-          <button type="button">
-            <Image
-              src={image ?? "/images/custom-logo.png"}
-              alt={type}
-              width={256}
-              height={256}
-              className="inline-block h-8 min-w-8 max-w-8 rounded-xl"
-            />
-          </button>
-          {/* 이미지 삭제 버튼 */}
-
-          {shouldShowDeleteImageButton && (
-            <button
-              type="button"
-              className="absolute -bottom-1 -right-1 inline-flex min-h-[18px] min-w-[18px] items-center justify-center rounded-full bg-danger text-foreground-inverted"
-              onClick={() => onClickDeleteImage(id)}
-            >
-              <span className="sr-only">이미지 삭제</span>
-              <Trash size={14} />
-            </button>
-          )}
-        </div>
+        <LinkImage src={image} alt={type} onDeleteImage={() => onClickDeleteImage(id)} />
 
         <EditableText
           label="Title"
@@ -344,13 +270,24 @@ export function LinkListItem({
 
       {/* body */}
       <div className="pl-6 pr-3">
-        <EditableText
-          label="URL"
-          value={url}
-          rightIcon={<PencilSimple size={16} className="ml-2 flex-shrink-0" />}
-          errorMessage={errorMessage.url}
-          onChange={handleChnageUrl}
-        />
+        {type === "custom" ? (
+          <CustomLinkEditor
+            id={id}
+            url={url}
+            title={title}
+            image={image}
+            onChangeUrl={(url) => onChangeUrl(id, url)}
+          />
+        ) : (
+          <SocialLinkEditor
+            id={id}
+            type={type}
+            url={url}
+            title={title}
+            image={image}
+            onChangeUrl={(url) => onChangeUrl(id, url)}
+          />
+        )}
       </div>
 
       {/* footer */}

--- a/src/components/links/link-list-item/social-link-editor.tsx
+++ b/src/components/links/link-list-item/social-link-editor.tsx
@@ -1,0 +1,84 @@
+import { useState } from "react";
+
+import { PencilSimple } from "@phosphor-icons/react";
+import toast from "react-hot-toast";
+
+import { EditableText } from "@/components/ui/editable-text";
+import { ENV } from "@/constants/env";
+import { getSnsUrl } from "@/lib/utils";
+import { Link } from "@/types/link";
+
+interface SocialLinkEditorProps {
+  id: Link["id"];
+  type: Link["type"];
+  url: Link["url"];
+  title?: Link["title"];
+  image?: Link["image"];
+  onChangeUrl: (url: string) => void;
+}
+
+export function SocialLinkEditor({
+  id,
+  type,
+  url,
+  title,
+  image,
+  onChangeUrl,
+}: SocialLinkEditorProps) {
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const username = url.replace(getSnsUrl(type), "") || `${type} 아이디를 입력하세요`;
+
+  const handleChangeUsername = async (value: string) => {
+    const newUsername = value.trim();
+
+    if (newUsername.length === 0) {
+      setErrorMessage("사용자명 입력해주세요");
+      onChangeUrl(value);
+      return;
+    }
+
+    if (newUsername.length > 254) {
+      setErrorMessage("입력가능한 길이를 초과했어요");
+      onChangeUrl(value);
+      return;
+    }
+
+    setErrorMessage("");
+    const newUrl = `${getSnsUrl(type)}${newUsername}`;
+    onChangeUrl(newUrl);
+
+    try {
+      const response = await fetch(`${ENV.apiUrl}/api/links/${id}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          id,
+          title,
+          image,
+          userId: 1, //FIXME: 인증된 회원 아이디
+          url: newUrl,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error("URL 수정에 실패했습니다");
+      }
+    } catch (error) {
+      console.error("URL 수정 중 오류 발생:", error);
+      toast("URL 수정에 실패했어요. 잠시후에 다시 시도해주세요");
+    }
+  };
+
+  return (
+    <EditableText
+      label="사용자 이름"
+      value={username}
+      rightIcon={<PencilSimple size={16} className="ml-1 flex-shrink-0" />}
+      errorMessage={errorMessage}
+      onChange={handleChangeUsername}
+    />
+  );
+}


### PR DESCRIPTION
## 🚀 링크 관리 중간 점검 전 수정
### 📝 요약
오늘 브라운백미팅때 나온 피드백 수정사항입니다
- 링크 추가 API: image 정보를 보낼 필요 없이 수정
  - 보내는 type에 따라 자동으로 image가 들어갑니다

- 이미지가 있을 때만 이미지 삭제버튼 렌더링 되도록 수정
<img width="106" alt="스크린샷 2024-09-10 오후 4 46 51" src="https://github.com/user-attachments/assets/8d75e868-79d8-4859-be58-6d418163d1cc">
<img width="106" alt="스크린샷 2024-09-10 오후 4 47 24" src="https://github.com/user-attachments/assets/6ec3453b-706f-4b62-b431-c834a8fc9888">


- 바로가기 버튼 추가
![image](https://github.com/user-attachments/assets/d621fb97-3399-45fa-b4ff-b9a12fd02537)

- 블록 가로축 뚫고 나가던 버그 수정
![image](https://github.com/user-attachments/assets/ee1cea1e-525b-4e2e-9d49-f6dbf2a79811)


- 소셜링크 사용자는 계정이름만 입력하도록 수정

https://github.com/user-attachments/assets/7901a76c-a313-4e4d-9e20-4ebaea642e26



### 🔗 이슈
#37 
### 🖼️ 스크린샷 (선택사항)
<!-- 보여줄 내용이 있는 경우 스크린샷을 추가해주세요. -->
### ℹ️ 추가 노트
<!-- 리뷰어가 알아야 할 다른 정보가 있다면 여기에 적어주세요. -->
